### PR TITLE
Set updated date to pubDate

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ for post in posts:
     fe.title(title)
     fe.link(href=url)
     fe.pubDate(date)
+    fe.updated(date)
     fe.summary(body)
     
     if image is not None:


### PR DESCRIPTION
In my feed reader every scraped entry is treated as a new significant update, therefore showing as new.

This is because the `updated` date of the atom feed is set to the time the feed is scraped.

As per atom specification this is semantically incorrect:

>    The "atom:updated" element is a Date construct indicating the most
   recent instant in time when an entry or feed was modified in a way
   the publisher considers significant.  Therefore, not all
   modifications necessarily result in a changed atom:updated value.

Source: https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.15

In this PR the `updated` date is set to the `pubDate`.

I think this should fix my issue and makes the feed more usable for others.